### PR TITLE
Add awscli to image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ apt-get update
 apt-get -qq -y install --no-install-recommends \
     ca-certificates curl tar git \
     libyaml-dev build-essential jq uuid-runtime \
-    awscli
+    unzip
 
 # Install our user and create directory to install actions-runner and the hostedtoolcache
 addgroup --gid 1000 "${RUNGROUP}" && adduser --uid 1000 --ingroup "${RUNGROUP}" --shell /bin/bash "${RUNUSER}"
@@ -24,6 +24,20 @@ tar xzf "./actions-runner-linux-x64-${ACTIONS_VERSION}.tar.gz"
 
 # Install .Net Core 3.x Linux Dependencies
 ./bin/installdependencies.sh
+
+# Install awscliv2
+curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip
+unzip awscliv2.zip
+./aws/install
+
+# Cleanup archive debris and unnecessary items to reduce image size
+rm -rf \
+      awscliv2.zip \
+      aws \
+      /usr/local/aws-cli/v2/*/dist/aws_completer \
+      /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
+      /usr/local/aws-cli/v2/*/dist/awscli/examples \
+      "actions-runner-linux-x64-${ACTIONS_VERSION}.tar.gz"
 
 # give privileges to our user
 chown -R "${RUNUSER}":"${RUNGROUP}" "/opt/hostedtoolcache"


### PR DESCRIPTION
Ishmael requested that the aws cli be included in the runner image. 

Added a cleanup step to `build.sh` which reduced the image size from 1.02GB to 744MB.

Testing:
- logged into a bash shell on the running image and verified the `aws --version` command succeeded.