### PR TITLE
Update Actions Runner Version to null

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update --no-cache \
     tar \
     ca-certificates
 
-ARG ACTIONS_VERSION="2.300.2"
+ARG ACTIONS_VERSION="null"
 
 RUN \
     # install runner


### PR DESCRIPTION
Automated update from Github Actions Runner version 2.300.2 to version null
Release Notes: https://github.com/actions/runner/releases/tag/vnull