### PR TITLE
Fix Trivy and Dockle

### DIFF
--- a/.dockleignore
+++ b/.dockleignore
@@ -1,0 +1,2 @@
+# see https://github.com/goodwithtech/dockle/issues/217 and https://github.com/dotnet/dotnet-docker/issues/4209 for why we're ignoring this
+CIS-DI-0009

--- a/.trivyignore
+++ b/.trivyignore
@@ -6,6 +6,7 @@ CVE-2021-44906
 CVE-2022-29244
 CVE-2022-3517
 CVE-2022-24999
+CVE-2022-25881
 
 # accept the risk of internal dotnet-core dependencies for the runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
     && mkdir runner \
     && tar xzf "actions-runner-linux-x64-${ACTIONS_VERSION}.tar.gz" --directory ./runner
 
-FROM ubuntu:22.04
+FROM ubuntu:22.10
 
 RUN addgroup --gid 1000 "runner" && adduser --uid 1000 --ingroup "runner" --shell /bin/bash "runner" \
     && mkdir -p "/home/runner" \


### PR DESCRIPTION
This change:
- ignores one Trivy finding we can't control (CVE-2022-25881 for a node dependency in the runner)
- updates the `ubuntu` image in our `Dockerfile` to address a Trivy finding we can control (CVE-2023-0286)
- adds a `.dockleignore` with an entry for finding that we can't control (CIS-DI-0009, see the comment in that file for more info)