### PR TITLE
Bump ubuntu to 23.04

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -85,7 +85,7 @@ jobs:
           docker run --rm \
           -e REPO_OWNER=Enterprise-CMCS \
           -e REPO_NAME=github-actions-runner-aws \
-          -e PERSONAL_ACCESS_TOKEN=${{ secrets.BHARVEY_GITHUB_TOKEN}} \
+          -e PERSONAL_ACCESS_TOKEN=${{ secrets.BHARVEY_GITHUB_TOKEN }} \
           -e RUNNER_UUID=${{ needs.set-runner-uuid.outputs.runner-uuid }} \
           ${{ env.SHA_TAG }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
 
 FROM ubuntu:23.04
 
-RUN groupadd --gid 1234 "runner" && useradd -g "runner" --shell /bin/bash "runner" \
+RUN groupadd "runner" && useradd -g "runner" --shell /bin/bash "runner" \
     && mkdir -p "/home/runner" \
     && chown -R "runner":"runner" "/home/runner"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN \
     && mkdir runner \
     && tar xzf "actions-runner-linux-x64-${ACTIONS_VERSION}.tar.gz" --directory ./runner
 
-FROM ubuntu:22.10
+FROM ubuntu:23.04
 
-RUN addgroup --gid 1000 "runner" && adduser --uid 1000 --ingroup "runner" --shell /bin/bash "runner" \
+RUN groupadd --gid 1234 "runner" && useradd -g "runner" --shell /bin/bash "runner" \
     && mkdir -p "/home/runner" \
     && chown -R "runner":"runner" "/home/runner"
 


### PR DESCRIPTION
I had to rework the `Dockerfile` a bit to get this to work.  Can't seem to find any documentation for it, but it looks like there were convenience wrappers around `groupadd` (`addgroup`)  and `useradd` (`adduser`) that were removed between versions.  So this change just calls them directly.  Also, I had to use a new group ID since `1000` is taken now. 