### PR TITLE
Update Actions Runner Version to 2.303.0

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -85,7 +85,7 @@ jobs:
           docker run --rm \
           -e REPO_OWNER=Enterprise-CMCS \
           -e REPO_NAME=github-actions-runner-aws \
-          -e PERSONAL_ACCESS_TOKEN=${{ secrets.BHARVEY_GITHUB_TOKEN }} \
+          -e PERSONAL_ACCESS_TOKEN=${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }} \
           -e RUNNER_UUID=${{ needs.set-runner-uuid.outputs.runner-uuid }} \
           ${{ env.SHA_TAG }}
 
@@ -100,7 +100,7 @@ jobs:
           until \
             curl -s \
               -H "Accept: application/vnd.github.v3+json" \
-              -u robot-mac-fc:${{ secrets.BHARVEY_GITHUB_TOKEN }} \
+              -u robot-mac-fc:${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }} \
               https://api.github.com/repos/Enterprise-CMCS/github-actions-runner-aws/actions/runners \
             | jq -e '.runners | .[] | select(.name == "${{ needs.set-runner-uuid.outputs.runner-uuid }}") | .status == "online"' >/dev/null
           do

--- a/.github/workflows/update-actions-runner.yml
+++ b/.github/workflows/update-actions-runner.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.BHARVEY_GITHUB_TOKEN }}
+          token: ${{ secrets.SERVICE_ACCOUNT_GITHUB_TOKEN }}
           commit-message: Update actions runner to new version
           author: robot-mac-fc <robot-mac-fc@users.noreply.github.com>
           branch: update-actions-runner-to-${{ steps.get-versions.outputs.release_tag }}

--- a/.github/workflows/update-actions-runner.yml
+++ b/.github/workflows/update-actions-runner.yml
@@ -3,6 +3,10 @@ name: Get latest GitHub Actions Runner
 on:
   schedule:
     - cron: "40 18 * * *"
+  # TODO remove
+  push:
+    branches:
+      - bharvey-secret
 jobs:
   update-runner:
     runs-on: ubuntu-latest

--- a/.trivyignore
+++ b/.trivyignore
@@ -7,9 +7,12 @@ CVE-2022-29244
 CVE-2022-3517
 CVE-2022-24999
 CVE-2022-25881
+CVE-2022-38900
 
 # accept the risk of internal dotnet-core dependencies for the runner
 
 CVE-2018-8292
 CVE-2019-0981
 CVE-2019-0980
+CVE-2019-0820
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update --no-cache \
     tar \
     ca-certificates
 
-ARG ACTIONS_VERSION="2.302.1"
+ARG ACTIONS_VERSION="2.303.0"
 
 RUN \
     # install runner


### PR DESCRIPTION
Automated update from Github Actions Runner version 2.302.1 to version 2.303.0
Release Notes: https://github.com/actions/runner/releases/tag/v2.303.0